### PR TITLE
Add initial auth docs  

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/iron

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -28,6 +28,7 @@ export default defineUserConfig({
         children: [
           { text: "Databases", link: "/databases/" },
           { text: "Workflows", link: "/workflows/" },
+          { text: "Application", link: "/application/" },
           { text: "Dashboard Components", link: "/dashboard-components/" },
           { text: "Cloud Functions", link: "/cloud-functions/" },
           { text: "Internationalization", link: "/internationalization/" },
@@ -52,6 +53,16 @@ export default defineUserConfig({
         link: "/workflows/",
         collapsable: false,
         children: getChildren("./docs/workflows"),
+      },
+      {
+        text: "Application",
+        collapsable: false,
+        children: [
+          {
+            text: "Authentication",
+            link: "/application/auth",
+          }
+        ]
       },
       {
         text: "Dashboard Components",

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -59,7 +59,7 @@ export default defineUserConfig({
         collapsable: false,
         children: [
           {
-            text: "Authentication",
+            text: "Auth",
             link: "/application/auth",
           }
         ]

--- a/docs/application/auth.md
+++ b/docs/application/auth.md
@@ -1,0 +1,40 @@
+---
+sidebarDepth: 1
+---
+# Auth
+
+Authentication and authorization for access to the ROAR Dashboard is handled by Firebase and Google Cloud Identity Platform.
+
+## Integration
+The ROAR projects implement the [`roar-firekit`](https://github.com/yeatmanlab/roar-firekit/) package to handle authentication and authorization, as well as a
+number of other operations. This SDK effectively serves as abstraction layer and wrapper around the Firebase SDK,
+providing a simple interface for interacting with the Firebase services. 
+
+The `roar-firekit` SDK is published on npm and can be installed via the following command:
+```bash
+npm i @bdelab/roar-firekit
+```
+
+## Authentication
+As we rely on [two distinct databases](/roar-docs/databases/), the `roar-firekit` package allows us to authenticate with both the
+admin and the assessment databases by providing the corresponding `RoarConfig` object during SDK initialization
+([example](https://github.com/yeatmanlab/roar-dashboard/blob/main/src/config/firebaseRoar.js)). 
+
+
+## Session Management
+As this application is designed to be used by children on shared devices, it was assumed that users might not always log
+out of the application when completing assessments. To address this, the ROAR Dashboard leverages `sessionStorage` to
+persist auth state. 
+
+## Session Timeout
+The ROAR Dashboard implements a session timeout feature to automatically log out users after a period of inactivity. By
+default, the idle threshold is set to 15 minutes, after which the user gets an additional 60 seconds to interact with
+the timeout dialog before being logged out.
+
+Due to the nature of the project and auth service, the session timeout feature was implemented on the frontend and can
+be configured by modifiying the following two environment variables:
+- `VITE_AUTH_SESSION_TIMEOUT_IDLE_THRESHOLD`<br>
+  The time in milliseconds after which the user is considered idle.<br>
+
+- `VITE_AUTH_SESSION_TIMEOUT_COUNTDOWN_DURATION`<br>
+  The time in milliseconds the user has to interact with the timeout dialog before being logged out. <br>

--- a/docs/application/auth.md
+++ b/docs/application/auth.md
@@ -1,11 +1,12 @@
 # Auth
 
-Authentication and authorization for access to the ROAR Dashboard is handled by Firebase and Google Cloud Identity Platform.
+Authentication and authorization for access to the ROAR Dashboard is handled by Firebase and Google Cloud Identity
+Platform.
 
 ## Integration
-The ROAR projects implement the [`roar-firekit`](https://github.com/yeatmanlab/roar-firekit/) package to handle authentication and authorization, as well as a
-number of other operations. This SDK effectively serves as abstraction layer and wrapper around the Firebase SDK,
-providing a simple interface for interacting with the Firebase services. 
+The ROAR projects implement the [`roar-firekit`](https://github.com/yeatmanlab/roar-firekit/) package to handle
+authentication and authorization, as well as a number of other operations. This SDK effectively serves as an abstraction
+layer and wrapper around the Firebase SDK, providing a simple interface for interacting with the Firebase services. 
 
 The `roar-firekit` SDK is published on npm and can be installed via the following command:
 ```bash
@@ -13,8 +14,8 @@ npm i @bdelab/roar-firekit
 ```
 
 ## Authentication
-As we rely on [two distinct databases](/roar-docs/databases/), the `roar-firekit` package allows us to authenticate with both the
-admin and the assessment databases by providing the corresponding `RoarConfig` object during SDK initialization
+As we rely on [two distinct databases](/roar-docs/databases/), the `roar-firekit` package allows us to authenticate with
+both the admin and the assessment databases by providing the corresponding `RoarConfig` object during SDK initialization
 ([example](https://github.com/yeatmanlab/roar-dashboard/blob/main/src/config/firebaseRoar.js)). 
 
 
@@ -23,13 +24,14 @@ As this application is designed to be used by children on shared devices, it was
 out of the application when completing assessments. To address this, the ROAR Dashboard leverages `sessionStorage` to
 persist auth state. 
 
+
 ## Session Timeout
 The ROAR Dashboard implements a session timeout feature to automatically log out users after a period of inactivity. By
 default, the idle threshold is set to 15 minutes, after which the user gets an additional 60 seconds to interact with
 the timeout dialog before being logged out.
 
 Due to the nature of the project and auth service, the session timeout feature was implemented on the frontend and can
-be configured by modifiying the following two environment variables:
+be configured by modifying the following two environment variables:
 - `VITE_AUTH_SESSION_TIMEOUT_IDLE_THRESHOLD`<br>
   The time in milliseconds after which the user is considered idle.<br>
 

--- a/docs/application/auth.md
+++ b/docs/application/auth.md
@@ -1,6 +1,3 @@
----
-sidebarDepth: 1
----
 # Auth
 
 Authentication and authorization for access to the ROAR Dashboard is handled by Firebase and Google Cloud Identity Platform.


### PR DESCRIPTION
## Proposed changes

This PR adds very basic Auth docs, including some details about session management and timeout. 

In the near future, we should extend these docs to explain in more detail both the Authentication and Authorization aspects, including but not limited to custom JWT claims, entitlements/access rights, etc.

<img width="2672" alt="Screenshot 2024-08-14 at 16 58 34" src="https://github.com/user-attachments/assets/d4e4bfda-9b6d-4174-bc05-1a8677b028ba">
