### PR TITLE
Add callout box to indicate that the next command will fail.

### DIFF
--- a/docs/developer/bigquery/README.md
+++ b/docs/developer/bigquery/README.md
@@ -151,6 +151,11 @@ LIMIT
 
 Researchers often want to export data to a CSV file. Let's see what happens when we change the format in that last query to `csv`:
 
+::: warning Failure is essential to learning.
+
+This next query will fail. You're not doing anything wrong. It is supposed to fail for pedagogical purposes. Just run the command and keep reading.
+:::
+
 ```bash
 bq query --nouse_legacy_sql --format=csv \
 'SELECT


### PR DESCRIPTION
This PR adds a callout box to the BigQuery documentation indicating that the next command will fail.