### PR TITLE
DOC: add Task and Variant System technical spec

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -79,6 +79,12 @@ export default defineUserConfig({
     sidebar: {
       "/developer/": [
         {
+          text: "Tasks and Variants",
+          link: "/developer/tasks-variants/",
+          collapsible: true,
+          children: getChildren("./docs/developer/tasks-variants"),
+        },
+        {
           text: "Databases",
           link: "/developer/databases/",
           collapsible: true,
@@ -123,7 +129,7 @@ export default defineUserConfig({
               link: "/developer/github-actions/dashboard",
               collapsible: true,
               children: getChildren(
-                "./docs/developer/github-actions/dashboard",
+                "./docs/developer/github-actions/dashboard"
               ),
             },
           ],
@@ -150,7 +156,7 @@ export default defineUserConfig({
               link: "/developer/backend-architecture/architecture/",
               collapsible: true,
               children: getChildren(
-                "./docs/developer/backend-architecture/architecture",
+                "./docs/developer/backend-architecture/architecture"
               ),
             },
             {
@@ -163,7 +169,7 @@ export default defineUserConfig({
                   link: "/developer/backend-architecture/api/classes/",
                   collapsible: true,
                   children: getChildren(
-                    "./docs/developer/backend-architecture/api/classes",
+                    "./docs/developer/backend-architecture/api/classes"
                   ),
                 },
                 {
@@ -171,7 +177,7 @@ export default defineUserConfig({
                   link: "/developer/backend-architecture/api/enumerations/",
                   collapsible: true,
                   children: getChildren(
-                    "./docs/developer/backend-architecture/api/enumerations",
+                    "./docs/developer/backend-architecture/api/enumerations"
                   ),
                 },
                 {
@@ -179,7 +185,7 @@ export default defineUserConfig({
                   link: "/developer/backend-architecture/api/functions/",
                   collapsible: true,
                   children: getChildren(
-                    "./docs/developer/backend-architecture/api/functions",
+                    "./docs/developer/backend-architecture/api/functions"
                   ),
                 },
                 {
@@ -187,7 +193,7 @@ export default defineUserConfig({
                   link: "/developer/backend-architecture/api/interfaces/",
                   collapsible: true,
                   children: getChildren(
-                    "./docs/developer/backend-architecture/api/interfaces",
+                    "./docs/developer/backend-architecture/api/interfaces"
                   ),
                 },
                 {
@@ -195,7 +201,7 @@ export default defineUserConfig({
                   link: "/developer/backend-architecture/api/type-aliases/",
                   collapsible: true,
                   children: getChildren(
-                    "./docs/developer/backend-architecture/api/type-aliases",
+                    "./docs/developer/backend-architecture/api/type-aliases"
                   ),
                 },
                 {
@@ -203,7 +209,7 @@ export default defineUserConfig({
                   link: "/developer/backend-architecture/api/variables/",
                   collapsible: true,
                   children: getChildren(
-                    "./docs/developer/backend-architecture/api/variables",
+                    "./docs/developer/backend-architecture/api/variables"
                   ),
                 },
               ],
@@ -213,7 +219,7 @@ export default defineUserConfig({
               link: "/developer/backend-architecture/examples/",
               collapsible: true,
               children: getChildren(
-                "./docs/developer/backend-architecture/examples",
+                "./docs/developer/backend-architecture/examples"
               ),
             },
             {
@@ -221,7 +227,7 @@ export default defineUserConfig({
               link: "/developer/backend-architecture/guides/",
               collapsible: true,
               children: getChildren(
-                "./docs/developer/backend-architecture/guides",
+                "./docs/developer/backend-architecture/guides"
               ),
             },
           ],
@@ -236,7 +242,7 @@ export default defineUserConfig({
               link: "/developer/cloud-functions/gse-roar-admin/",
               collapsible: true,
               children: getChildren(
-                "./docs/developer/cloud-functions/gse-roar-admin",
+                "./docs/developer/cloud-functions/gse-roar-admin"
               ),
             },
             {
@@ -244,7 +250,7 @@ export default defineUserConfig({
               link: "/developer/cloud-functions/gse-roar-assessment/",
               collapsible: true,
               children: getChildren(
-                "./docs/developer/cloud-functions/gse-roar-assessment",
+                "./docs/developer/cloud-functions/gse-roar-assessment"
               ),
             },
           ],
@@ -289,7 +295,7 @@ export default defineUserConfig({
               link: "/developer/emulation/running-the-emulator/",
               collapsible: true,
               children: getChildren(
-                "./docs/developer/emulation/running-the-emulator",
+                "./docs/developer/emulation/running-the-emulator"
               ),
             },
             {
@@ -297,7 +303,7 @@ export default defineUserConfig({
               link: "/developer/emulation/emulator-configuration-guide/",
               collapsible: true,
               children: getChildren(
-                "./docs/developer/emulation/emulator-configuration-guide",
+                "./docs/developer/emulation/emulator-configuration-guide"
               ),
             },
           ],

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,9 @@ home: true
 title: Home
 heroImage: /assets/roar-logo.svg
 actions:
+  - text: Tasks and Variants
+    link: /developer/tasks-variants/
+    type: secondary
   - text: Databases
     link: /developer/databases/
     type: secondary

--- a/docs/developer/tasks-variants/README.md
+++ b/docs/developer/tasks-variants/README.md
@@ -1,0 +1,277 @@
+# ROAR Task Configuration and Variant System: Technical Specification
+
+## 1. Purpose and Scope
+
+ROAR supports configurable tasks used in assessments. This document defines the technical specification for how researchers interact with configurable ROAR tasks, including:
+
+* Creating and referencing **variants** (parameter configurations)
+* Versioning **tasks**
+* Supporting a flexible yet reproducible **dev mode**
+* Executing and logging **task runs**
+
+This spec ensures consistency, auditability, and scalability across both development and production contexts.
+
+---
+
+## 2. System Overview
+
+The ROAR task system consists of the following components:
+
+* **Tasks**: Assessment units with parameterizable behavior
+
+  A task is a unit of assessment content and logic (e.g., "ROAR Word"). Tasks are versioned to allow for backwards-compatible and breaking changes.
+
+* **Task Versions**: Versioned logic and default handling per task
+
+  A specific, versioned implementation of a task (e.g., v1.2.0). Task versions define default parameter values and behavior. Changes to logic, scoring, or parameter handling result in a new task version.
+
+* **Variants**: Immutable parameter sets identified by a stable `variant_id`
+
+  A variant is a unique, immutable configuration of a task's parameters. It is identified by a variant ID, which acts like a DOI. Once created, it will always refer to the same parameter set.
+
+* **Task Spec**: `{ variant_id, task_version }` — uniquely defines runtime behavior
+
+  A Task Spec is the pair `{ variant_id, task_version }`. This combination fully determines the behavior of a task run, including default parameters, logic, and scoring. It is important to realize that the variant_id is not tied to any specific task version. The same variant_id may be used with different task versions, and it is the combination of variant_id and task_version — the Task Spec — that determines the full behavior of a task run.
+
+* **Runs**: Executions of a task with a specific `variant_id` and `task_version`
+
+  A run is a specific instance of a student or researcher interacting with a task. Every run references a variant_id and a task_version_id, allowing the exact task behavior to be reconstructed from the database.
+
+### Component Flow Diagram
+
+```mermaid
+graph TD
+  UI[Researcher UI] --> API[API: run task]
+  API -->|dev mode| Dev[Create dev variant]
+  API -->|published mode| Lookup[Lookup variant]
+  Dev --> Resolve[Resolve parameters]
+  Lookup --> Resolve
+  Resolve --> Execute[Execute task]
+  Execute --> Log[Log run with variant_id + task_version]
+```
+
+## 3. Runtime Behavior by Mode
+
+### Published Mode
+
+* Researcher specifies a known `variant_id`
+* System fetches parameter set from `variant_parameters`
+* Task version is explicitly selected (or defaults to latest stable)
+* Runtime merges parameters with task version's defaults
+* Run is executed and logged with `variant_id`, `task_version_id`
+
+### Dev Mode
+
+* Researcher provides a custom parameter set
+* Because dev mode may include unversioned or unpublished code changes, the `task_version_id` logged for dev runs may be set to `NULL`, or a special placeholder (e.g., `"unversioned-dev"`) to indicate non-reproducibility. These runs are not guaranteed to be reproducible even though their variant parameters are stored.
+* System auto-mints a new variant with `is_dev_variant = true`
+* A `variant_id` is generated and stored in `variants`
+* Task is run with that variant and task version
+* Run is logged with the new `variant_id`
+
+---
+
+## 4. Dev Mode Behavior
+
+::: info Reproducibility in Dev Mode
+
+Dev-mode runs may use unpublished or unversioned code. While the parameter configuration is stored, exact task behavior may not be fully reproducible unless the development environment is version-controlled and pinned. The task_version_id for dev runs may be null or reference a placeholder.
+:::
+
+Dev mode is intended for experimentation without polluting the public registry.
+
+* Dev-mode variants are flagged as `is_dev_variant = true` and are not shown in public researcher dashboards or included in standard reporting or analytics views. This ensures that only validated, production-ready variants are visible for data analysis or deployment purposes.
+* They may contain parameters not yet in production use
+* These variants are excluded from public dashboards and analytics by default
+* A dev variant can be promoted to a published variant by toggling `is_dev_variant = false` and adding a name/description
+* Since runs completed in the dev environment do not have a specified task version,
+
+---
+
+## 5. Edge Cases and Error Handling
+
+| Scenario                                             | Expected Behavior                                |
+| ---------------------------------------------------- | ------------------------------------------------ |
+| Missing `variant_id` in published mode               | 400 error with message "variant\_id is required" |
+| Parameter mismatch with task version                 | Task resolves using defaults; log warning        |
+| Dev-mode variant identical to existing published one | Deduplicate by comparing canonical param hash    |
+| Attempt to promote already published variant         | No-op; return existing variant info              |
+| Unknown parameter in dev mode                        | Allow execution, but log a warning that the parameter is not recognized by the current task version. This supports flexibility while helping researchers catch typos or misconfigurations.  |
+| Running a dev variant in production                  | Reject request with 400 or 403 error. Dev variants are not permitted in production. |
+
+---
+
+## 6. Design Rationale
+
+* **Separation of variant and version** allows stable IDs while supporting evolving task logic
+* **Variant ID as immutable key** ensures reproducibility and clean version control
+* **Dev variants stored as real variants** avoids custom logic for freeform runs, simplifying the schema
+* **Task Spec abstraction** clearly captures full execution context for a run
+
+---
+
+## 7. API Contract
+
+### `POST /api/runs`
+
+Creates a new run
+
+* In published mode, it uses a supplied `variant_id`
+* In dev mode, it mints a new dev variant (if needed) using the provided parameters
+
+#### Dev Mode Request
+
+```json
+POST /api/runs
+{
+  "task_slug": "swr",
+  "task_version": "v2.0.0",
+  "parameters": { "num_items": 8, "shuffle": true },
+  "user_id": 12345
+}
+```
+
+#### Published Mode Request
+
+```json
+POST /api/runs
+{
+  "task_slug": "swr",
+  "task_version": "v2.0.0",
+  "variant_id": 123,
+  "user_id": 12345
+}
+```
+
+#### Response
+
+```json
+{
+  "run_id": 12345,
+  "user_id": 12345,
+  "task_slug": "swr",
+  "task_version": "v2.0.0",
+  "variant_id": 123,
+  "parameters": {
+    "num_items": 8,
+    "shuffle": true
+  },
+  "is_dev_variant": false,
+}
+```
+
+### `GET /api/runs/{run_id}`
+
+Returns metadata for a specific run.
+
+```json
+{
+  "run_id": 12345,
+  "user_id": 12345,
+  "task_slug": "swr",
+  "task_version": "v2.0.0",
+  "variant_id": 123,
+  "parameters": {
+    "num_items": 8,
+    "shuffle": true
+  },
+  "is_dev_variant": false,
+}
+```
+
+### `GET /api/tasks/`
+
+Returns metadata for all available tasks.
+
+### `GET /api/tasks/{task_slug}`
+
+Returns metadata for a specific task.
+
+### `GET /api/tasks/{task_slug}/versions`
+
+Returns metadata for all available versions of a specific task. Dev variants are excluded by default.
+
+---
+
+## 8. SQL Schema
+
+### `tasks`
+
+```sql
+CREATE TABLE tasks (
+  id SERIAL PRIMARY KEY,
+  slug TEXT UNIQUE NOT NULL,
+  display_name TEXT NOT NULL,
+  description TEXT,
+  created_at TIMESTAMP DEFAULT now()
+);
+```
+
+### `task_versions`
+
+```sql
+CREATE TABLE task_versions (
+  id SERIAL PRIMARY KEY,
+  task_id INTEGER REFERENCES tasks(id) ON DELETE CASCADE,
+  version TEXT NOT NULL,
+  description TEXT,
+  created_at TIMESTAMP DEFAULT now(),
+  UNIQUE(task_id, version)
+);
+```
+
+### `variants`
+
+```sql
+CREATE TABLE variants (
+  id SERIAL PRIMARY KEY,
+  task_id INTEGER REFERENCES tasks(id) ON DELETE CASCADE,
+  variant_id TEXT UNIQUE NOT NULL,
+  name TEXT,
+  description TEXT,
+  is_dev_variant BOOLEAN DEFAULT false,
+  created_at TIMESTAMP DEFAULT now()
+);
+```
+
+### `variant_parameters`
+
+```sql
+CREATE TABLE variant_parameters (
+  id SERIAL PRIMARY KEY,
+  variant_id INTEGER REFERENCES variants(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  value JSONB NOT NULL,
+  type TEXT,
+  UNIQUE(variant_id, name)
+);
+```
+
+### `runs`
+
+```sql
+CREATE TABLE runs (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+  task_version_id INTEGER REFERENCES task_versions(id),
+  variant_id INTEGER REFERENCES variants(id) NOT NULL,
+  created_at TIMESTAMP DEFAULT now()
+  -- Note: This schema only includes fields relevant to the task/variant system.
+  -- Additional run metadata (e.g. device info, session ID, assignment ID, etc.) will be added in future extensions to the ROAR documentation.
+);
+```
+
+---
+
+## 9. Migration Plan
+
+* Migrate existing Firestore variants into the `variants` and `variant_parameters` tables
+* Dev-mode Firestore runs can be replayed into SQL by minting variants
+* Legacy tasks may require shimming in the API to handle missing variant metadata
+* After migration, new runs must go through the SQL-backed system
+
+---
+
+## Summary
+
+This spec provides a consistent, extensible, and reproducible system for managing task configuration and execution in ROAR. The abstraction of a **Task Spec = { variant ID, task version }** enables clarity for researchers, traceability for engineers, and scalability for the system.


### PR DESCRIPTION
## Summary

This PR adds a new technical specification page to the ROAR documentation describing the architecture and behavior of the Task Configuration and Variant System.

It formalizes how tasks, variants, and runs are managed, with a focus on reproducibility, extensibility, and developer/researcher usability.

## What's Included

- Definitions for core entities: Task, Task Version, Variant, Run, and the Task Spec abstraction
- Behavioral specification for:
  - Published mode (using stable variant IDs)
  - Dev mode (with automatic dev variant minting)
- Design rationale for separating parameter configuration from task code versions
- SQL schema covering tasks, task_versions, variants, variant_parameters, and runs
- Edge case handling and data validation expectations
- API contract including:
  - `POST /api/runs` (with dev variant minting)
  - `GET /api/tasks`, `GET /api/tasks/:slug`, `GET /api/tasks/:slug/variants`
  - `GET /api/runs/:id`
- Sample requests/responses and RESTful naming conventions

## What is NOT included

- Swagger/OpenAPI JSON files
- Run metadata beyond variant/version linkage
- Implementation of variant promotion or garbage collection of dev variants