### PR TITLE
BigQuery ROAR Admin Docs

### DIFF
--- a/docs/developer/bigquery/README.md
+++ b/docs/developer/bigquery/README.md
@@ -93,15 +93,15 @@ To query assesement data, you will need the `bq` command line tool to interact w
 
 1. Install the `bq` tool if it is not already included:
 
-    ```bash
-    gcloud components install bq
-    ```
+   ```bash
+   gcloud components install bq
+   ```
 
 1. Verify installation:
 
-    ```bash
-    bq version
-    ```
+   ```bash
+   bq version
+   ```
 
 The initialization step above should have authenticated you into your Google account. But if you need to log in again, use
 
@@ -157,7 +157,7 @@ This next query will fail. You're not doing anything wrong. It is supposed to fa
 :::
 
 ```bash
-bq query --nouse_legacy_sql --format=csv \
+bq query --nouse_legacy_sql --format=csv --header=true, --overwrite=true\
 'SELECT
   *
 FROM

--- a/docs/developer/bigquery/administrations.md
+++ b/docs/developer/bigquery/administrations.md
@@ -1,0 +1,35 @@
+# BigQuery schema: administrations
+
+The BigQuery table `gse-roar-admin.admin.administrations` conforms to the following schema:
+
+| Field name             | Data type      | Key type | Description                                                                            |
+| :--------------------- | :------------- | :------: | :------------------------------------------------------------------------------------- |
+| document_name          | STRING         |    UK    | The database document path                                                             |
+| timestamp              | TIMESTAMP      |          | The timestamp indicating when the database document was last modifed                   |
+| assessments            | ARRAY\<STRING> |          | The array of assessments associated with the administration                            |
+| classes_assigned       | ARRAY\<STRING> |          | The array of classes assigned to the administration                                    |
+| created_by             | STRING         |          | The unique ID of the user who created the administration                               |
+| date_closed            | TIMESTAMP      |          | The timestamp indicating when the administration was closed                            |
+| date_created           | TIMESTAMP      |          | The timestamp indicating when the administration was created                           |
+| date_closed            | TIMESTAMP      |          | The timestamp indicating when the administration was closed                            |
+| districts_assigned     | ARRAY\<STRING> |          | The array of districts assigned to the administration                                  |
+| families_assigned      | ARRAY\<STRING> |          | The array of families assigned to the administration                                   |
+| groups_assigned        | ARRAY\<STRING> |          | The array of groups assigned to the administration                                     |
+| legal                  | STRING         |          | The assent and/or consent documents associated with the administration                 |
+| minimal_orgs_districts | ARRAY\<STRING> |          | The array of top level districts which assigned the administration to its organization |
+| minimal_orgs_schools   | ARRAY\<STRING> |          | The array of top level schools which assigned the administration to its organization   |
+| minimal_orgs_classes   | ARRAY\<STRING> |          | The array of top level classes which assigned the administration to its organization   |
+| minimal_orgs_groups    | ARRAY\<STRING> |          | The array of top level groups which assigned the administration to its organization    |
+| minimal_orgs_families  | ARRAY\<STRING> |          | The array of top level families which assigned the administration to its organization  |
+| admin_name             | STRING         |          | The internal name of the administration                                                |
+| public_name            | STRING         |          | The public name of the administration                                                  |
+| read_orgs_districts    | ARRAY\<STRING> |          | The array of districts which can read the administration                               |
+| read_orgs_schools      | ARRAY\<STRING> |          | The array of schools which can read the administration                                 |
+| read_orgs_classes      | ARRAY\<STRING> |          | The array of classes which can read the administration                                 |
+| read_orgs_groups       | ARRAY\<STRING> |          | The array of groups which can read the administration                                  |
+| read_orgs_families     | ARRAY\<STRING> |          | The array of families which can read the administration                                |
+| schools_assigned       | ARRAY\<STRING> |          | The array of schools assigned to the administration                                    |
+| sequential             | BOOLEAN        |          | Whether the administration is sequential or not                                        |
+| tags                   | ARRAY\<STRING> |          | The array of tags assigned to the administration                                       |
+| test_data              | BOOLEAN        |          | Whether the administration is a test data or not                                       |
+| administration_id      | STRING         |    PK    | The unique identifier of the administration                                            |

--- a/docs/developer/bigquery/bigquery-rc-file.md
+++ b/docs/developer/bigquery/bigquery-rc-file.md
@@ -1,0 +1,52 @@
+# BigQuery Runtime Configuration File
+
+A BigQuery runtime configuration file (`.bigqueryrc`) is a text file that sets default options for the `bq` command-line tool. This file eliminates the need to repeatedly specify common CLI options for every query.
+
+## What It Does
+
+The `.bigqueryrc` file allows you to:
+
+- Set default formatting options (like JSON output)
+- Configure SQL dialect preferences
+- Specify default locations and logging settings
+- Avoid typing repetitive command-line flags
+
+## Setup
+
+1. Create a file named `.bigqueryrc` in your home directory
+2. Add your preferred default options (see example below)
+3. The settings will automatically apply to all `bq` commands
+
+## Recommended Configuration
+
+Below is a recommended `.bigqueryrc` file for ROAR development:
+
+```text
+--location=us
+--apilog=stdout
+--format=prettyjson
+
+[query]
+--use_legacy_sql=false
+
+[mk]
+--use_legacy_sql=false
+```
+
+## Configuration Options Explained
+
+- `--location=us`: Sets the default location for BigQuery operations to US region
+- `--apilog=stdout`: Displays API request logs to standard output for debugging
+- `--format=prettyjson`: Formats query results as readable JSON
+- `--use_legacy_sql=false`: Uses standard SQL syntax instead of legacy BigQuery SQL
+
+## Overriding Defaults
+
+You can override any `.bigqueryrc` setting for specific commands:
+
+- **Command-line flags**: `bq query --format=csv "SELECT * FROM table"`
+- **Environment variables**: `export BIGQUERY_LOCATION=eu` before running commands
+
+For the complete list of available options, see the [official documentation][link_bq_rc_file].
+
+[link_bq_rc_file]: https://cloud.google.com/bigquery/docs/bq-command-line-tool#adding_flags_to_bigqueryrc

--- a/docs/developer/bigquery/classes.md
+++ b/docs/developer/bigquery/classes.md
@@ -1,27 +1,27 @@
 # BigQuery schema: classes
 
-The BigQuery table `gse-roar-assessment:assessment.classes` conforms to the following schema.
+The BigQuery table `gse-roar-assessment.assessment.classes` conforms to the following schema.
 
-| Field name | Data type | Key type | Description |
-| :--- | :--- | :---: | :--- |
-| class_id | STRING | PK | The unique class ID in the ROAR system |
-| document_name | STRING | UK | The database document path |
-| timestamp | TIMESTAMP | | A timestamp indicating when the database document was last modified |
-| archived | BOOLEAN | | Whether this class has been archived or unenrolled |
-| clever_roster_created | TIMESTAMP || The date this class created its Clever roster |
-| clever_roster_last_modified | TIMESTAMP || The date this class's roster was last modified in Clever |
-| current_activation_code | STRING | UK | The class's current parent sign-up activation code |
-| district_id | STRING | FK | The ID of this class's district |
-| grade | STRING || The grade associated with this class |
-| is_classlink | BOOLEAN || Indicates whether this class is a ClassLink class |
-| is_clever | BOOLEAN || Indicates whether this class is a Clever class |
-| is_demo_data | BOOLEAN || Indicates whether this class is a demo class |
-| is_test_data | BOOLEAN || Indicates whether this class is a test class |
-| last_roar_sync | TIMESTAMP | | The date and time when this class's data was last synced between Clever and ROAR |
-| last_updated | TIMESTAMP | | The date and time this class was last updated in ROAR |
-| name | STRING || The class name |
-| school_id | STRING | FK | The ID of this class's school |
-| school_level | STRING || The school level (e.g., elementary, middle, etc) |
-| subject | STRING || The class subject |
-| tags | ARRAY\<STRING> || An array of metadata tags for this class |
-| valid_activation_codes | ARRAY\<STRING> | UK | An array of valid activation codes for this class |
+| Field name                  | Data type      | Key type | Description                                                                      |
+| :-------------------------- | :------------- | :------: | :------------------------------------------------------------------------------- |
+| class_id                    | STRING         |    PK    | The unique class ID in the ROAR system                                           |
+| document_name               | STRING         |    UK    | The database document path                                                       |
+| timestamp                   | TIMESTAMP      |          | A timestamp indicating when the database document was last modified              |
+| archived                    | BOOLEAN        |          | Whether this class has been archived or unenrolled                               |
+| clever_roster_created       | TIMESTAMP      |          | The date this class created its Clever roster                                    |
+| clever_roster_last_modified | TIMESTAMP      |          | The date this class's roster was last modified in Clever                         |
+| current_activation_code     | STRING         |    UK    | The class's current parent sign-up activation code                               |
+| district_id                 | STRING         |    FK    | The ID of this class's district                                                  |
+| grade                       | STRING         |          | The grade associated with this class                                             |
+| is_classlink                | BOOLEAN        |          | Indicates whether this class is a ClassLink class                                |
+| is_clever                   | BOOLEAN        |          | Indicates whether this class is a Clever class                                   |
+| is_demo_data                | BOOLEAN        |          | Indicates whether this class is a demo class                                     |
+| is_test_data                | BOOLEAN        |          | Indicates whether this class is a test class                                     |
+| last_roar_sync              | TIMESTAMP      |          | The date and time when this class's data was last synced between Clever and ROAR |
+| last_updated                | TIMESTAMP      |          | The date and time this class was last updated in ROAR                            |
+| name                        | STRING         |          | The class name                                                                   |
+| school_id                   | STRING         |    FK    | The ID of this class's school                                                    |
+| school_level                | STRING         |          | The school level (e.g., elementary, middle, etc)                                 |
+| subject                     | STRING         |          | The class subject                                                                |
+| tags                        | ARRAY\<STRING> |          | An array of metadata tags for this class                                         |
+| valid_activation_codes      | ARRAY\<STRING> |    UK    | An array of valid activation codes for this class                                |

--- a/docs/developer/bigquery/districts.md
+++ b/docs/developer/bigquery/districts.md
@@ -1,35 +1,35 @@
 # BigQuery schema: districts
 
-The BigQuery table `gse-roar-assessment:assessment.districts` conforms to the following schema.
+The BigQuery table `gse-roar-assessment.assessment.districts` conforms to the following schema.
 
-| Field name | Data type | Key type | Description |
-| :--- | :--- | :---: | :--- |
-| district_id | STRING | PK | The unique district ID in the ROAR system |
-| document_name | STRING | UK | The database document path |
-| timestamp | TIMESTAMP | | A timestamp indicating when the database document was last modified |
-| abbreviation | STRING || A human-readable abbreviation for this district |
-| archived | BOOLEAN | | Whether this district has been archived or unenrolled |
-| clever_launch_date | TIMESTAMP || The date this this district launched in Clever |
-| clever_roster_created | TIMESTAMP || The date this district created its Clever roster |
-| clever_roster_last_modified | TIMESTAMP || The date this district's roster was last modified in Clever |
-| clever_roster_pause_start | TIMESTAMP || Indicates when the district's data gets paused to reflect last year's data in Clever |
-| clever_roster_pause_end | TIMESTAMP || Indicates when the district data is unpaused to reflect data for the new school year |
-| current_activation_code | STRING | UK | The district's current parent sign-up activation code |
-| is_classlink | BOOLEAN || Indicates whether this district is a ClassLink district |
-| is_clever | BOOLEAN || Indicates whether this district is a Clever district |
-| is_demo_data | BOOLEAN || Indicates whether this district is a demo district |
-| is_test_data | BOOLEAN || Indicates whether this district is a test district |
-| location_address | STRING || The district address |
-| location_city | STRING || The district city |
-| location_state | STRING || The district state |
-| location_zip | STRING || The district zip code |
-| last_roar_sync | TIMESTAMP | | The date and time when this district's data was last synced between Clever and ROAR |
-| last_updated | TIMESTAMP | | The date and time this district was last updated in ROAR |
-| mdr_number | STRING | UK | The district's MDR number |
-| name | STRING || The district name |
-| nces_id | STRING | UK | The district's NCES ID |
-| public_name | STRING || The district's public facing name |
-| schools | ARRAY\<STRING> | FK | An array of IDs for the district's current schools |
-| schools_archived | ARRAY\<STRING> | FK | An array of IDs for the district's archived (i.e., unenrolled) schools |
-| tags | ARRAY\<STRING> || An array of metadata tags for this district |
-| valid_activation_codes | ARRAY\<STRING> | UK | An array of valid activation codes for this district |
+| Field name                  | Data type      | Key type | Description                                                                          |
+| :-------------------------- | :------------- | :------: | :----------------------------------------------------------------------------------- |
+| district_id                 | STRING         |    PK    | The unique district ID in the ROAR system                                            |
+| document_name               | STRING         |    UK    | The database document path                                                           |
+| timestamp                   | TIMESTAMP      |          | A timestamp indicating when the database document was last modified                  |
+| abbreviation                | STRING         |          | A human-readable abbreviation for this district                                      |
+| archived                    | BOOLEAN        |          | Whether this district has been archived or unenrolled                                |
+| clever_launch_date          | TIMESTAMP      |          | The date this this district launched in Clever                                       |
+| clever_roster_created       | TIMESTAMP      |          | The date this district created its Clever roster                                     |
+| clever_roster_last_modified | TIMESTAMP      |          | The date this district's roster was last modified in Clever                          |
+| clever_roster_pause_start   | TIMESTAMP      |          | Indicates when the district's data gets paused to reflect last year's data in Clever |
+| clever_roster_pause_end     | TIMESTAMP      |          | Indicates when the district data is unpaused to reflect data for the new school year |
+| current_activation_code     | STRING         |    UK    | The district's current parent sign-up activation code                                |
+| is_classlink                | BOOLEAN        |          | Indicates whether this district is a ClassLink district                              |
+| is_clever                   | BOOLEAN        |          | Indicates whether this district is a Clever district                                 |
+| is_demo_data                | BOOLEAN        |          | Indicates whether this district is a demo district                                   |
+| is_test_data                | BOOLEAN        |          | Indicates whether this district is a test district                                   |
+| location_address            | STRING         |          | The district address                                                                 |
+| location_city               | STRING         |          | The district city                                                                    |
+| location_state              | STRING         |          | The district state                                                                   |
+| location_zip                | STRING         |          | The district zip code                                                                |
+| last_roar_sync              | TIMESTAMP      |          | The date and time when this district's data was last synced between Clever and ROAR  |
+| last_updated                | TIMESTAMP      |          | The date and time this district was last updated in ROAR                             |
+| mdr_number                  | STRING         |    UK    | The district's MDR number                                                            |
+| name                        | STRING         |          | The district name                                                                    |
+| nces_id                     | STRING         |    UK    | The district's NCES ID                                                               |
+| public_name                 | STRING         |          | The district's public facing name                                                    |
+| schools                     | ARRAY\<STRING> |    FK    | An array of IDs for the district's current schools                                   |
+| schools_archived            | ARRAY\<STRING> |    FK    | An array of IDs for the district's archived (i.e., unenrolled) schools               |
+| tags                        | ARRAY\<STRING> |          | An array of metadata tags for this district                                          |
+| valid_activation_codes      | ARRAY\<STRING> |    UK    | An array of valid activation codes for this district                                 |

--- a/docs/developer/bigquery/families.md
+++ b/docs/developer/bigquery/families.md
@@ -1,20 +1,20 @@
 # BigQuery schema: families
 
-The BigQuery table `gse-roar-assessment:assessment.families` conforms to the following schema.
+The BigQuery table `gse-roar-assessment.assessment.families` conforms to the following schema.
 
-| Field name | Data type | Key type | Description |
-| :--- | :--- | :---: | :--- |
-| family_id | STRING | PK | The unique family ID in the ROAR system |
-| document_name | STRING | UK | The database document path |
-| timestamp | TIMESTAMP || A timestamp indicating when the database document was last modified |
-| abbreviation | STRING || A human-readable abbreviation for this family |
-| archived | BOOLEAN | | Whether this family has been archived or unenrolled |
-| created_at | TIMESTAMP || A timestamp indicating when this family was created |
-| current_activation_code | STRING | UK | The family's current parent sign-up activation code |
-| is_demo_data | BOOLEAN || Indicates whether this family is a demo school |
-| is_test_data | BOOLEAN || Indicates whether this family is a test school |
-| last_updated | TIMESTAMP | | The date and time this family was last updated in ROAR |
-| name | STRING || The family name |
-| subgroups | ARRAY\<STRING> | FK | An array of IDs for all groups associated with this family |
-| tags | ARRAY\<STRING> || An array of metadata tags for this family |
-| valid_activation_codes | ARRAY\<STRING> | UK | An array of valid activation codes for this family |
+| Field name              | Data type      | Key type | Description                                                         |
+| :---------------------- | :------------- | :------: | :------------------------------------------------------------------ |
+| family_id               | STRING         |    PK    | The unique family ID in the ROAR system                             |
+| document_name           | STRING         |    UK    | The database document path                                          |
+| timestamp               | TIMESTAMP      |          | A timestamp indicating when the database document was last modified |
+| abbreviation            | STRING         |          | A human-readable abbreviation for this family                       |
+| archived                | BOOLEAN        |          | Whether this family has been archived or unenrolled                 |
+| created_at              | TIMESTAMP      |          | A timestamp indicating when this family was created                 |
+| current_activation_code | STRING         |    UK    | The family's current parent sign-up activation code                 |
+| is_demo_data            | BOOLEAN        |          | Indicates whether this family is a demo school                      |
+| is_test_data            | BOOLEAN        |          | Indicates whether this family is a test school                      |
+| last_updated            | TIMESTAMP      |          | The date and time this family was last updated in ROAR              |
+| name                    | STRING         |          | The family name                                                     |
+| subgroups               | ARRAY\<STRING> |    FK    | An array of IDs for all groups associated with this family          |
+| tags                    | ARRAY\<STRING> |          | An array of metadata tags for this family                           |
+| valid_activation_codes  | ARRAY\<STRING> |    UK    | An array of valid activation codes for this family                  |

--- a/docs/developer/bigquery/groups.md
+++ b/docs/developer/bigquery/groups.md
@@ -1,25 +1,25 @@
 # BigQuery schema: groups
 
-The BigQuery table `gse-roar-assessment:assessment.groups` conforms to the following schema.
+The BigQuery table `gse-roar-assessment.assessment.groups` conforms to the following schema.
 
-| Field name | Data type | Key type | Description |
-| :--- | :--- | :---: | :--- |
-| group_id | STRING | PK | The unique group ID in the ROAR system |
-| document_name | STRING | UK | The database document path |
-| timestamp | TIMESTAMP | | A timestamp indicating when the database document was last modified |
-| abbreviation | STRING || A human-readable abbreviation for this group |
-| archived | BOOLEAN | | Whether this group has been archived or unenrolled |
-| current_activation_code | STRING | UK | The group's current parent sign-up activation code |
-| family_id | STRING | FK | The ID of the family associated with this group (if this is a sub-group) |
-| is_demo_data | BOOLEAN || Indicates whether this group is a demo class |
-| is_test_data | BOOLEAN || Indicates whether this group is a test class |
-| last_updated | TIMESTAMP | | The date and time this group was last updated in ROAR |
-| location_address | STRING || The group address |
-| location_city | STRING || The group city |
-| location_state | STRING || The group state |
-| location_zip | STRING || The group zip code |
-| name | STRING || The group name |
-| parent_org_id | STRING | FK | The ID of the parent organization (if this is a sub-group) |
-| parent_org_type | STRING || The type of parent organization (if this is a sub-group) |
-| tags | ARRAY\<STRING> || An array of metadata tags for this group |
-| valid_activation_codes | ARRAY\<STRING> | UK | An array of valid activation codes for this group |
+| Field name              | Data type      | Key type | Description                                                              |
+| :---------------------- | :------------- | :------: | :----------------------------------------------------------------------- |
+| group_id                | STRING         |    PK    | The unique group ID in the ROAR system                                   |
+| document_name           | STRING         |    UK    | The database document path                                               |
+| timestamp               | TIMESTAMP      |          | A timestamp indicating when the database document was last modified      |
+| abbreviation            | STRING         |          | A human-readable abbreviation for this group                             |
+| archived                | BOOLEAN        |          | Whether this group has been archived or unenrolled                       |
+| current_activation_code | STRING         |    UK    | The group's current parent sign-up activation code                       |
+| family_id               | STRING         |    FK    | The ID of the family associated with this group (if this is a sub-group) |
+| is_demo_data            | BOOLEAN        |          | Indicates whether this group is a demo class                             |
+| is_test_data            | BOOLEAN        |          | Indicates whether this group is a test class                             |
+| last_updated            | TIMESTAMP      |          | The date and time this group was last updated in ROAR                    |
+| location_address        | STRING         |          | The group address                                                        |
+| location_city           | STRING         |          | The group city                                                           |
+| location_state          | STRING         |          | The group state                                                          |
+| location_zip            | STRING         |          | The group zip code                                                       |
+| name                    | STRING         |          | The group name                                                           |
+| parent_org_id           | STRING         |    FK    | The ID of the parent organization (if this is a sub-group)               |
+| parent_org_type         | STRING         |          | The type of parent organization (if this is a sub-group)                 |
+| tags                    | ARRAY\<STRING> |          | An array of metadata tags for this group                                 |
+| valid_activation_codes  | ARRAY\<STRING> |    UK    | An array of valid activation codes for this group                        |

--- a/docs/developer/bigquery/legal-versions.md
+++ b/docs/developer/bigquery/legal-versions.md
@@ -1,0 +1,10 @@
+# BigQuery schema: legal_versions
+
+The BigQuery table `gse-roar-admin.admin.legal_versions` conforms to the following schema:
+
+| Field name       | Data type | Key type | Description                                                           |
+| :--------------- | :-------- | :------: | :-------------------------------------------------------------------- |
+| document_name    | STRING    |    UK    | The database document path                                            |
+| timestamp        | TIMESTAMP |          | The timestamp indicating when the database document was last modified |
+| valid_from       | DATE      |          | The date from which the document is valid                             |
+| legal_version_id | STRING    |          | The unique identifier for the legal version                           |

--- a/docs/developer/bigquery/legal.md
+++ b/docs/developer/bigquery/legal.md
@@ -1,0 +1,14 @@
+# BigQuery schema: legal
+
+The BigQuery table `gse-roar-admin.admin.legal` conforms to the following schema:
+
+| Field name        | Data type | Key type | Description                                                           |
+| :---------------- | :-------- | :------: | :-------------------------------------------------------------------- |
+| document_name     | STRING    |    UK    | The database document path                                            |
+| timestamp         | TIMESTAMP |          | The timestamp indicating when the database document was last modified |
+| current_commit    | STRING    |          | The current commit hash of the database document                      |
+| file_name         | STRING    |          | The name of the file associated with the legal document               |
+| github_org        | STRING    |          | The GitHub organization associated with the legal document            |
+| github_repository | STRING    |          | The GitHub repository associated with the legal document              |
+| params            | STRING    |          | The parameters associated with the legal document                     |
+| legal_id          | STRING    |          | The unique identifier for the legal document                          |

--- a/docs/developer/bigquery/querying-admin-data.md
+++ b/docs/developer/bigquery/querying-admin-data.md
@@ -1,0 +1,57 @@
+# Querying Admin Data
+
+ROAR's [admin data][link_admin_firestore_doc] is automatically exported from Firestore to [BigQuery][link_bigquery] for analysis and reporting. This document explains how to query admin data in BigQuery.
+
+## Key Differences from Assessment Data
+
+Admin data queries follow the same principles as [querying assessment data][link_querying_assessment_data], but with these important differences:
+
+- **Location**: Admin data is stored in a separate BigQuery project (`gse-roar-admin`) under the `admin` dataset
+- **Privacy**: Admin data includes personally identifiable information (PII) that requires special handling
+- **Access**: Admin data access is more restricted due to privacy requirements
+
+## Shared and Unique Tables
+
+### Shared Tables
+
+These tables exist in both admin and assessment datasets with identical schemas:
+
+- `classes`
+- `districts`
+- `families`
+- `groups`
+- `schools`
+
+### Users Table Differences
+
+The `users` table exists in both datasets but with different schemas:
+
+- **Admin dataset** (`gse-roar-admin.admin.users`): Contains complete user information including PII
+- **Assessment dataset** (`gse-roar-assessment.assessment.users`): PII fields are omitted for privacy
+
+## Available Tables
+
+The admin dataset (`gse-roar-admin.admin`) contains the following tables:
+
+- [`administrations`][link_schema_administrations]
+- [`classes`][link_schema_classes]
+- [`districts`][link_schema_districts]
+- [`families`][link_schema_families]
+- [`groups`][link_schema_groups]
+- [`legal`][link_schema_legal]
+- [`legal_versions`][link_schema_legal_versions]
+- [`schools`][link_schema_schools]
+- [`users`][link_schema_users]
+
+[link_querying_assessment_data]: ./README.md
+[link_admin_firestore_doc]: ../databases/admin.md
+[link_bigquery]: https://cloud.google.com/bigquery?hl=en
+[link_schema_administrations]: ./administrations.md
+[link_schema_classes]: ./classes.md
+[link_schema_districts]: ./districts.md
+[link_schema_families]: ./families.md
+[link_schema_groups]: ./groups.md
+[link_schema_legal]: ./legal.md
+[link_schema_legal_versions]: ./legal-versions.md
+[link_schema_schools]: ./schools.md
+[link_schema_users]: ./users.md

--- a/docs/developer/bigquery/schools.md
+++ b/docs/developer/bigquery/schools.md
@@ -1,36 +1,36 @@
 # BigQuery schema: schools
 
-The BigQuery table `gse-roar-assessment:assessment.schools` conforms to the following schema.
+The BigQuery table `gse-roar-assessment.assessment.schools` conforms to the following schema.
 
-| Field name | Data type | Key type | Description |
-| :--- | :--- | :---: | :--- |
-| school_id | STRING | PK | The unique school ID in the ROAR system |
-| document_name | STRING | UK | The database document path |
-| timestamp | TIMESTAMP || A timestamp indicating when the database document was last modified |
-| abbreviation | STRING || A human-readable abbreviation for this school |
-| archived | BOOLEAN | | Whether this school has been archived or unenrolled |
-| classes | ARRAY\<STRING> | FK | An array of IDs for the schools's current classes |
-| classes_archived | ARRAY\<STRING> | FK | An array of IDs for the schools's archived (i.e., unenrolled) classes |
-| clever_roster_created | TIMESTAMP || The date this school created its Clever roster |
-| clever_roster_last_modified | TIMESTAMP || The date this schools's roster was last modified in Clever |
-| current_activation_code | STRING | UK | The school's current parent sign-up activation code |
-| district_id | STRING | FK | The ID of this school's district |
-| is_classlink | BOOLEAN || Indicates whether this school is a ClassLink school |
-| is_clever | BOOLEAN || Indicates whether this school is a Clever school |
-| is_demo_data | BOOLEAN || Indicates whether this school is a demo school |
-| is_test_data | BOOLEAN || Indicates whether this school is a test school |
-| location_address | STRING || The school address |
-| location_city | STRING || The school city |
-| location_state | STRING || The school state |
-| location_zip | STRING || The school zip code |
-| low_grade | STRING || The lowest grade served at this school |
-| high_grade | STRING || The highest grade served at this school |
-| last_roar_sync | TIMESTAMP | | The date and time when this school's data was last synced between Clever and ROAR |
-| last_updated | TIMESTAMP | | The date and time this school was last updated in ROAR |
-| mdr_number | STRING | UK | The school's MDR number |
-| name | STRING || The school name |
-| nces_id | STRING | UK | The school's NCES ID |
-| school_number | STRING || District or county school identifier |
-| state_id | STRING || State school identifier |
-| tags | ARRAY\<STRING> || An array of metadata tags for this school |
-| valid_activation_codes | ARRAY\<STRING> | UK | An array of valid activation codes for this school |
+| Field name                  | Data type      | Key type | Description                                                                       |
+| :-------------------------- | :------------- | :------: | :-------------------------------------------------------------------------------- |
+| school_id                   | STRING         |    PK    | The unique school ID in the ROAR system                                           |
+| document_name               | STRING         |    UK    | The database document path                                                        |
+| timestamp                   | TIMESTAMP      |          | A timestamp indicating when the database document was last modified               |
+| abbreviation                | STRING         |          | A human-readable abbreviation for this school                                     |
+| archived                    | BOOLEAN        |          | Whether this school has been archived or unenrolled                               |
+| classes                     | ARRAY\<STRING> |    FK    | An array of IDs for the schools's current classes                                 |
+| classes_archived            | ARRAY\<STRING> |    FK    | An array of IDs for the schools's archived (i.e., unenrolled) classes             |
+| clever_roster_created       | TIMESTAMP      |          | The date this school created its Clever roster                                    |
+| clever_roster_last_modified | TIMESTAMP      |          | The date this schools's roster was last modified in Clever                        |
+| current_activation_code     | STRING         |    UK    | The school's current parent sign-up activation code                               |
+| district_id                 | STRING         |    FK    | The ID of this school's district                                                  |
+| is_classlink                | BOOLEAN        |          | Indicates whether this school is a ClassLink school                               |
+| is_clever                   | BOOLEAN        |          | Indicates whether this school is a Clever school                                  |
+| is_demo_data                | BOOLEAN        |          | Indicates whether this school is a demo school                                    |
+| is_test_data                | BOOLEAN        |          | Indicates whether this school is a test school                                    |
+| location_address            | STRING         |          | The school address                                                                |
+| location_city               | STRING         |          | The school city                                                                   |
+| location_state              | STRING         |          | The school state                                                                  |
+| location_zip                | STRING         |          | The school zip code                                                               |
+| low_grade                   | STRING         |          | The lowest grade served at this school                                            |
+| high_grade                  | STRING         |          | The highest grade served at this school                                           |
+| last_roar_sync              | TIMESTAMP      |          | The date and time when this school's data was last synced between Clever and ROAR |
+| last_updated                | TIMESTAMP      |          | The date and time this school was last updated in ROAR                            |
+| mdr_number                  | STRING         |    UK    | The school's MDR number                                                           |
+| name                        | STRING         |          | The school name                                                                   |
+| nces_id                     | STRING         |    UK    | The school's NCES ID                                                              |
+| school_number               | STRING         |          | District or county school identifier                                              |
+| state_id                    | STRING         |          | State school identifier                                                           |
+| tags                        | ARRAY\<STRING> |          | An array of metadata tags for this school                                         |
+| valid_activation_codes      | ARRAY\<STRING> |    UK    | An array of valid activation codes for this school                                |

--- a/docs/developer/bigquery/user_runs.md
+++ b/docs/developer/bigquery/user_runs.md
@@ -1,31 +1,31 @@
 # BigQuery schema: user_runs
 
-The BigQuery table `gse-roar-assessment:assessment.user_runs` conforms to the following schema.
+The BigQuery table `gse-roar-assessment.assessment.user_runs` conforms to the following schema.
 
-| Field name | Data type | Key type | Description |
-| :--- | :--- | :---: | :--- |
-| run_id | STRING | PK | The run's unique ID |
-| roar_uid | STRING | FK | The user's unique ID in the ROAR system |
-| document_name | STRING | UK | The database document path |
-| timestamp | TIMESTAMP || A timestamp indicating when the database document was last modified |
-| assigning_districts | ARRAY\<STRING> | FK | An array of IDs for districts that assigned this run's task to this user |
-| assigning_schools | ARRAY\<STRING> | FK | An array of IDs for schools that assigned this run's task to this user |
-| assigning_classes | ARRAY\<STRING> | FK | An array of IDs for classes that assigned this run's task to this user |
-| assigning_families | ARRAY\<STRING> | FK | An array of IDs for families that assigned this run's task to this user |
-| assigning_groups | ARRAY\<STRING> | FK | An array of IDs for groups that assigned this run's task to this user |
-| assignment_id | STRING | FK | The ID for the assignment (administration) that this run belongs to |
-| best_run | BOOLEAN || Indicates whether this run is the "best" run and is used for scoring |
-| cloud_sync_timestamp | TIMESTAMP || An internal timestamp used to coordinate ROAR's cloud functions |
-| completed | BOOLEAN || Indicates whether the participant completed this run |
-| engagement_flags | STRING || A serialized (stringified) JSON object indicating the engagement flags for this run |
-| reliable | BOOLEAN || Indicates whether this run is classified as reliable for scoring |
-| scores | STRING || A serialized (stringified) JSON object containing scores for this run |
-| task_id | STRING | FK | The ID for this run's task (assessment) |
-| task_version | STRING || The version of the assessment |
-| time_finished | TIMESTAMP || Time the run was completed |
-| time_started | TIMESTAMP || Time the run was started |
-| user_birth_month | STRING || The user's birth month |
-| user_birth_year | STRING || The user's birth year |
-| user_grade | STRING || The user's grade |
-| user_school_level | STRING || The user's school level |
-| variant_id | STRING | FK | The ID for this run's task variant |
+| Field name           | Data type      | Key type | Description                                                                         |
+| :------------------- | :------------- | :------: | :---------------------------------------------------------------------------------- |
+| run_id               | STRING         |    PK    | The run's unique ID                                                                 |
+| roar_uid             | STRING         |    FK    | The user's unique ID in the ROAR system                                             |
+| document_name        | STRING         |    UK    | The database document path                                                          |
+| timestamp            | TIMESTAMP      |          | A timestamp indicating when the database document was last modified                 |
+| assigning_districts  | ARRAY\<STRING> |    FK    | An array of IDs for districts that assigned this run's task to this user            |
+| assigning_schools    | ARRAY\<STRING> |    FK    | An array of IDs for schools that assigned this run's task to this user              |
+| assigning_classes    | ARRAY\<STRING> |    FK    | An array of IDs for classes that assigned this run's task to this user              |
+| assigning_families   | ARRAY\<STRING> |    FK    | An array of IDs for families that assigned this run's task to this user             |
+| assigning_groups     | ARRAY\<STRING> |    FK    | An array of IDs for groups that assigned this run's task to this user               |
+| assignment_id        | STRING         |    FK    | The ID for the assignment (administration) that this run belongs to                 |
+| best_run             | BOOLEAN        |          | Indicates whether this run is the "best" run and is used for scoring                |
+| cloud_sync_timestamp | TIMESTAMP      |          | An internal timestamp used to coordinate ROAR's cloud functions                     |
+| completed            | BOOLEAN        |          | Indicates whether the participant completed this run                                |
+| engagement_flags     | STRING         |          | A serialized (stringified) JSON object indicating the engagement flags for this run |
+| reliable             | BOOLEAN        |          | Indicates whether this run is classified as reliable for scoring                    |
+| scores               | STRING         |          | A serialized (stringified) JSON object containing scores for this run               |
+| task_id              | STRING         |    FK    | The ID for this run's task (assessment)                                             |
+| task_version         | STRING         |          | The version of the assessment                                                       |
+| time_finished        | TIMESTAMP      |          | Time the run was completed                                                          |
+| time_started         | TIMESTAMP      |          | Time the run was started                                                            |
+| user_birth_month     | STRING         |          | The user's birth month                                                              |
+| user_birth_year      | STRING         |          | The user's birth year                                                               |
+| user_grade           | STRING         |          | The user's grade                                                                    |
+| user_school_level    | STRING         |          | The user's school level                                                             |
+| variant_id           | STRING         |    FK    | The ID for this run's task variant                                                  |

--- a/docs/developer/bigquery/user_trials.md
+++ b/docs/developer/bigquery/user_trials.md
@@ -1,53 +1,53 @@
 # BigQuery schema: user_trials
 
-The BigQuery table `gse-roar-assessment:assessment.user_trials` conforms to the following schema.
+The BigQuery table `gse-roar-assessment.assessment.user_trials` conforms to the following schema.
 
-| Field name | Data type | Key type | Description |
-| :--- | :--- | :---: | :--- |
-| trial_id | STRING | PK | The unique trial ID |
-| run_id | STRING | FK | The ID of the run that this trial belongs to |
-| roar_uid | STRING | FK | The user's unique ID in the ROAR system |
-| document_name | STRING | UK | The database document path |
-| timestamp | TIMESTAMP || A timestamp indicating when the database document was last modified |
-| assessment_stage | STRING || Indicates the type of trial, either "practice_response" or "test_response" |
-| audio_feedback | STRING || |
-| block | STRING || |
-| block_id | STRING || |
-| button_response | INTEGER || Indicates the button that the participant clicked on |
-| corpus_id | STRING || |
-| correct | INTEGER || Indicates whether the response was correct |
-| correct_response | STRING || Indicates the expected correct response |
-| difficulty | STRING || Item difficulty parameter |
-| goal | STRING || |
-| internal_node_id | STRING || The internal node ID of this trial in the jsPsych timeline |
-| item | STRING || |
-| item_id | STRING || |
-| keyboard_response | STRING || Indicates the keyboard button that the participant pressed |
-| realpseudo | STRING || |
-| response | STRING || |
-| response_input | STRING || |
-| response_source | STRING || |
-| rt | INTEGER || Reaction time in milliseconds |
-| save_trial | BOOLEAN || Always true |
-| server_timestamp | TIMESTAMP || A timestamp indicating when this trials was saved to Firestore |
-| start_time | STRING || Indicates the start time of the run |
-| start_time_unix | INTEGER || Indicates the start time of the run as measured by the number of non-leap second since the Unix epoch |
-| stim | STRING || |
-| stimulus | STRING || The stimulus that was presented to the participant |
-| stimulus_rule | STRING || |
-| story | BOOLEAN || |
-| subtask | STRING || |
-| task_id | STRING || The ID of the task to which this trial belongs |
-| theta_estimate | FLOAT || Ability estimate |
-| theta_estimate_2 | FLOAT || A second ability estimate |
-| theta_std_err | FLOAT || The standard error in the ability estimate |
-| theat_std_err_2 | FLOAT || The standard error in the second ability estimate |
-| time_elapsed | INTEGER || Time elapsed since the beginning of the run |
-| timezone | STRING || The timezone in which this trial was completed |
-| trial_num_block | INTEGER || |
-| trial_num_total | INTEGER || |
-| trial_index | INTEGER || |
-| trial_type | STRING || |
-| truefalse | STRING || |
-| word | STRING || |
-| meta_data | STRING || A serialized (a.k.a. stringified) JSON object containing all other trial data |
+| Field name        | Data type | Key type | Description                                                                                           |
+| :---------------- | :-------- | :------: | :---------------------------------------------------------------------------------------------------- |
+| trial_id          | STRING    |    PK    | The unique trial ID                                                                                   |
+| run_id            | STRING    |    FK    | The ID of the run that this trial belongs to                                                          |
+| roar_uid          | STRING    |    FK    | The user's unique ID in the ROAR system                                                               |
+| document_name     | STRING    |    UK    | The database document path                                                                            |
+| timestamp         | TIMESTAMP |          | A timestamp indicating when the database document was last modified                                   |
+| assessment_stage  | STRING    |          | Indicates the type of trial, either "practice_response" or "test_response"                            |
+| audio_feedback    | STRING    |          |                                                                                                       |
+| block             | STRING    |          |                                                                                                       |
+| block_id          | STRING    |          |                                                                                                       |
+| button_response   | INTEGER   |          | Indicates the button that the participant clicked on                                                  |
+| corpus_id         | STRING    |          |                                                                                                       |
+| correct           | INTEGER   |          | Indicates whether the response was correct                                                            |
+| correct_response  | STRING    |          | Indicates the expected correct response                                                               |
+| difficulty        | STRING    |          | Item difficulty parameter                                                                             |
+| goal              | STRING    |          |                                                                                                       |
+| internal_node_id  | STRING    |          | The internal node ID of this trial in the jsPsych timeline                                            |
+| item              | STRING    |          |                                                                                                       |
+| item_id           | STRING    |          |                                                                                                       |
+| keyboard_response | STRING    |          | Indicates the keyboard button that the participant pressed                                            |
+| realpseudo        | STRING    |          |                                                                                                       |
+| response          | STRING    |          |                                                                                                       |
+| response_input    | STRING    |          |                                                                                                       |
+| response_source   | STRING    |          |                                                                                                       |
+| rt                | INTEGER   |          | Reaction time in milliseconds                                                                         |
+| save_trial        | BOOLEAN   |          | Always true                                                                                           |
+| server_timestamp  | TIMESTAMP |          | A timestamp indicating when this trials was saved to Firestore                                        |
+| start_time        | STRING    |          | Indicates the start time of the run                                                                   |
+| start_time_unix   | INTEGER   |          | Indicates the start time of the run as measured by the number of non-leap second since the Unix epoch |
+| stim              | STRING    |          |                                                                                                       |
+| stimulus          | STRING    |          | The stimulus that was presented to the participant                                                    |
+| stimulus_rule     | STRING    |          |                                                                                                       |
+| story             | BOOLEAN   |          |                                                                                                       |
+| subtask           | STRING    |          |                                                                                                       |
+| task_id           | STRING    |          | The ID of the task to which this trial belongs                                                        |
+| theta_estimate    | FLOAT     |          | Ability estimate                                                                                      |
+| theta_estimate_2  | FLOAT     |          | A second ability estimate                                                                             |
+| theta_std_err     | FLOAT     |          | The standard error in the ability estimate                                                            |
+| theat_std_err_2   | FLOAT     |          | The standard error in the second ability estimate                                                     |
+| time_elapsed      | INTEGER   |          | Time elapsed since the beginning of the run                                                           |
+| timezone          | STRING    |          | The timezone in which this trial was completed                                                        |
+| trial_num_block   | INTEGER   |          |                                                                                                       |
+| trial_num_total   | INTEGER   |          |                                                                                                       |
+| trial_index       | INTEGER   |          |                                                                                                       |
+| trial_type        | STRING    |          |                                                                                                       |
+| truefalse         | STRING    |          |                                                                                                       |
+| word              | STRING    |          |                                                                                                       |
+| meta_data         | STRING    |          | A serialized (a.k.a. stringified) JSON object containing all other trial data                         |

--- a/docs/developer/bigquery/users.md
+++ b/docs/developer/bigquery/users.md
@@ -1,34 +1,76 @@
 # BigQuery schema: users
 
-The BigQuery table `gse-roar-assessment:assessment.users` conforms to the following schema.
+## Assessment Users
 
-| Field name | Data type | Key type | Description |
-| :--- | :--- | :---: | :--- |
-| roar_uid | STRING | PK | The user's unique ID in the ROAR system |
-| document_name | STRING | UK | The database document path |
-| timestamp | TIMESTAMP | | A timestamp indicating when the database document was last modified |
-| archived | BOOLEAN | | Whether this user has been archived or unenrolled |
-| assessment_pid | STRING | UK | A human readable and unique "participant ID" |
-| assessment_uid | STRING | UK | The UID associated with this user's Firebase auth account in the gse-roar-assessment project |
-| birth_month | INTEGER | | Birth month |
-| birth_year | INTEGER | | Birth year |
-| classes_all | ARRAY\<STRING> | FK | An array of all class IDs associated with this user |
-| classes_current | ARRAY\<STRING> | FK | An array of currently enrolled class IDs associated with this user |
-| districts_all | ARRAY\<STRING> | FK | An array of all district IDs associated with this user |
-| districts_current | ARRAY\<STRING> | FK | An array of currently enrolled district IDs associated with this user |
-| families_all | ARRAY\<STRING> | FK | An array of all family IDs associated with this user |
-| families_current | ARRAY\<STRING> | FK | An array of currently enrolled family IDs associated with this user |
-| grade | STRING | | The current grade of the user |
-| groups_all | ARRAY\<STRING> | FK | An array of all group IDs associated with this user |
-| groups_current | ARRAY\<STRING> | FK | An array of currently enrolled group IDs associated with this user |
-| last_roar_sync | TIMESTAMP | | The date and time when this user's data was last synced between Clever and ROAR |
-| last_updated | TIMESTAMP | | The date and time this user was last updated in ROAR |
-| school_level | STRING | | The user's school level (e.g., elementary, middle, etc) |
-| schools_all | ARRAY\<STRING> | FK | An array of all school IDs associated with this user |
-| schools_current | ARRAY\<STRING> | FK | An array of currently enrolled school IDs associated with this user |
-| sso_type | STRING | | The user's single sign-on (SSO) provider |
-| user_type | STRING | | The user type (e.g., student, admin, educator) |
-| username | STRING UK | | The user's username |
-| email | STRING UK | | The user's email |
-| tasks | ARRAY\<STRING> | FK | An array of task IDs that this user has attempted |
-| variants | ARRAY\<STRING> | FK | An array of variant IDs that this user has attempted |
+The BigQuery table `gse-roar-assessment.assessment.users` conforms to the following schema.
+
+| Field name        | Data type      | Key type | Description                                                                                  |
+| :---------------- | :------------- | :------: | :------------------------------------------------------------------------------------------- |
+| roar_uid          | STRING         |    PK    | The user's unique ID in the ROAR system                                                      |
+| document_name     | STRING         |    UK    | The database document path                                                                   |
+| timestamp         | TIMESTAMP      |          | A timestamp indicating when the database document was last modified                          |
+| archived          | BOOLEAN        |          | Whether this user has been archived or unenrolled                                            |
+| assessment_pid    | STRING         |    UK    | A human readable and unique "participant ID"                                                 |
+| assessment_uid    | STRING         |    UK    | The UID associated with this user's Firebase auth account in the gse-roar-assessment project |
+| birth_month       | INTEGER        |          | Birth month                                                                                  |
+| birth_year        | INTEGER        |          | Birth year                                                                                   |
+| classes_all       | ARRAY\<STRING> |    FK    | An array of all class IDs associated with this user                                          |
+| classes_current   | ARRAY\<STRING> |    FK    | An array of currently enrolled class IDs associated with this user                           |
+| districts_all     | ARRAY\<STRING> |    FK    | An array of all district IDs associated with this user                                       |
+| districts_current | ARRAY\<STRING> |    FK    | An array of currently enrolled district IDs associated with this user                        |
+| families_all      | ARRAY\<STRING> |    FK    | An array of all family IDs associated with this user                                         |
+| families_current  | ARRAY\<STRING> |    FK    | An array of currently enrolled family IDs associated with this user                          |
+| grade             | STRING         |          | The current grade of the user                                                                |
+| groups_all        | ARRAY\<STRING> |    FK    | An array of all group IDs associated with this user                                          |
+| groups_current    | ARRAY\<STRING> |    FK    | An array of currently enrolled group IDs associated with this user                           |
+| last_roar_sync    | TIMESTAMP      |          | The date and time when this user's data was last synced between Clever and ROAR              |
+| last_updated      | TIMESTAMP      |          | The date and time this user was last updated in ROAR                                         |
+| school_level      | STRING         |          | The user's school level (e.g., elementary, middle, etc)                                      |
+| schools_all       | ARRAY\<STRING> |    FK    | An array of all school IDs associated with this user                                         |
+| schools_current   | ARRAY\<STRING> |    FK    | An array of currently enrolled school IDs associated with this user                          |
+| sso_type          | STRING         |          | The user's single sign-on (SSO) provider                                                     |
+| user_type         | STRING         |          | The user type (e.g., student, admin, educator)                                               |
+| username          | STRING UK      |          | The user's username                                                                          |
+| email             | STRING UK      |          | The user's email                                                                             |
+| tasks             | ARRAY\<STRING> |    FK    | An array of task IDs that this user has attempted                                            |
+| variants          | ARRAY\<STRING> |    FK    | An array of variant IDs that this user has attempted                                         |
+
+## Admin Users
+
+The BigQuery table `gse-roar-admin.admin.users` conforms to the following schema.
+
+| Field name         | Data type      | Key type | Description                                                                                  |
+| :----------------- | :------------- | :------: | :------------------------------------------------------------------------------------------- |
+| roar_uid           | STRING         |    PK    | The user's unique ID in the ROAR system                                                      |
+| document_name      | STRING         |    UK    | The database document path                                                                   |
+| timestamp          | TIMESTAMP      |          | A timestamp indicating when the database document was last modified                          |
+| archived           | BOOLEAN        |          | Whether this user has been archived or unenrolled                                            |
+| assessment_pid     | STRING         |    UK    | A human readable and unique "participant ID"                                                 |
+| assessment_uid     | STRING         |    UK    | The UID associated with this user's Firebase auth account in the gse-roar-assessment project |
+| classes_all        | ARRAY\<STRING> |    FK    | An array of all class IDs associated with this user                                          |
+| classes_current    | ARRAY\<STRING> |    FK    | An array of currently enrolled class IDs associated with this user                           |
+| districts_all      | ARRAY\<STRING> |    FK    | An array of all district IDs associated with this user                                       |
+| districts_current  | ARRAY\<STRING> |    FK    | An array of currently enrolled district IDs associated with this user                        |
+| dob                | DATE           |          | The date of birth of the user                                                                |
+| families_all       | ARRAY\<STRING> |    FK    | An array of all family IDs associated with this user                                         |
+| families_current   | ARRAY\<STRING> |    FK    | An array of currently enrolled family IDs associated with this user                          |
+| gender             | STRING         |          | The gender of the user                                                                       |
+| grade              | STRING         |          | The current grade of the user                                                                |
+| groups_all         | ARRAY\<STRING> |    FK    | An array of all group IDs associated with this user                                          |
+| groups_current     | ARRAY\<STRING> |    FK    | An array of currently enrolled group IDs associated with this user                           |
+| hispanic_ethnicity | STRING         |          | Whether the user is Hispanic or Latino                                                       |
+| last_roar_sync     | TIMESTAMP      |          | The date and time when this user's data was last synced between Clever and ROAR              |
+| last_updated       | TIMESTAMP      |          | The date and time this user was last updated in ROAR                                         |
+| race               | STRING         |          | The user's race or ethnicity (e.g., Asian, Black, Hispanic, White, etc)                      |
+| school_level       | STRING         |          | The user's school level (e.g., elementary, middle, etc)                                      |
+| schools_all        | ARRAY\<STRING> |    FK    | An array of all school IDs associated with this user                                         |
+| schools_current    | ARRAY\<STRING> |    FK    | An array of currently enrolled school IDs associated with this user                          |
+| sis_id             | STRING         |          | The user's school information system (SIS) ID                                                |
+| sso_type           | STRING         |          | The user's single sign-on (SSO) provider                                                     |
+| state_id           | STRING         |          | The user's state ID                                                                          |
+| student_number     | STRING         |          | The user's student number                                                                    |
+| user_type          | STRING         |          | The user type (e.g., student, admin, educator)                                               |
+| username           | STRING UK      |          | The user's username                                                                          |
+| email              | STRING UK      |          | The user's email                                                                             |
+| tasks              | ARRAY\<STRING> |    FK    | An array of task IDs that this user has attempted                                            |
+| variants           | ARRAY\<STRING> |    FK    | An array of variant IDs that this user has attempted                                         |


### PR DESCRIPTION
This PR updates roar-docs to include documentation on the ROAR BigQuery Admin dataset. It also adds an example .bigqueryrc file, and corrects some typos in the README.
