### PR TITLE
fix/Properly Link to Admin User Schema

### DIFF
--- a/docs/developer/bigquery/querying-admin-data.md
+++ b/docs/developer/bigquery/querying-admin-data.md
@@ -54,4 +54,4 @@ The admin dataset (`gse-roar-admin.admin`) contains the following tables:
 [link_schema_legal]: ./legal.md
 [link_schema_legal_versions]: ./legal-versions.md
 [link_schema_schools]: ./schools.md
-[link_schema_users]: ./users.md
+[link_schema_users]: ./users.md#admin-users


### PR DESCRIPTION
When selecting the link to the "users" table from the "Querying Admin Data" section, properly redirecet to the specific admin users schema.